### PR TITLE
Fixed problem with loading mime types from the assembly

### DIFF
--- a/elFinder.Net/Mime.cs
+++ b/elFinder.Net/Mime.cs
@@ -4,37 +4,42 @@ using System.Reflection;
 
 namespace ElFinder
 {
+    using System;
+
     internal static class Mime
     {
         private static Dictionary<string, string> _mimeTypes;
+        
         static Mime()
         {
             _mimeTypes = new Dictionary<string, string>();
             Assembly assembly = Assembly.GetExecutingAssembly();
-            if(assembly != null)
+
+            using (var stream = assembly.GetManifestResourceStream("elFinder.Net.mimeTypes.txt"))
             {
-                using (Stream stream = assembly.GetManifestResourceStream("ElFinder.mimeTypes.txt"))
+                using (var reader = new StreamReader(stream))
                 {
-                    using (StreamReader reader = new StreamReader(stream))
+                    while (!reader.EndOfStream)
                     {
-                        while (!reader.EndOfStream)
+                        string line = reader.ReadLine();
+
+                        if (string.IsNullOrEmpty(line) || line.StartsWith("#"))
                         {
-                            string line = reader.ReadLine();
-                            line = line.Trim();
-                            if (!string.IsNullOrWhiteSpace(line) && line[0] != '#')
+                            continue;
+                        }
+
+                        var parts = line.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+                        if (parts.Length > 1)
+                        {
+                            var mime = parts[0];
+
+                            for (var i = 1; i < parts.Length; i++)
                             {
-                                string[] parts = line.Split(' ');
-                                if (parts.Length > 1)
+                                var ext = parts[i].ToLower();
+                                if (!_mimeTypes.ContainsKey(ext))
                                 {
-                                    string mime = parts[0];
-                                    for (int i = 1; i < parts.Length; i++)
-                                    {
-                                        string ext = parts[i].ToLower();
-                                        if (!_mimeTypes.ContainsKey(ext))
-                                        {
-                                            _mimeTypes.Add(ext, mime);
-                                        }
-                                    }
+                                    _mimeTypes.Add(ext, mime);
                                 }
                             }
                         }
@@ -42,16 +47,15 @@ namespace ElFinder
                 }
             }
         }
+
         public static string GetMimeType(string extension)
         {
             if (_mimeTypes.ContainsKey(extension))
             {
                 return _mimeTypes[extension];
             }
-            else
-            {
-                return "unknown";
-            }                    
+            
+            return "unknown";
         }
     }
 }

--- a/elFinder.Net/elFinder.Net.csproj
+++ b/elFinder.Net/elFinder.Net.csproj
@@ -72,7 +72,7 @@
     <Compile Include="Response\TreeResponse.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="mimeTypes.txt" />
+    <EmbeddedResource Include="mimeTypes.txt" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
The code doesn't work because the mime textfile is not embedded into the dll. The name was also wrong when trying to get it out of the assembly.