### PR TITLE
When using "rm" the error is not returned when the target is not found

### DIFF
--- a/elFinder.Net/Facade/Connector.cs
+++ b/elFinder.Net/Facade/Connector.cs
@@ -96,7 +96,7 @@ namespace ElFinder
                     {
                         IEnumerable<string> targets = GetTargetsArray(request);
                         if (targets == null)
-                            Error.MissedParameter("targets");
+                            return Error.MissedParameter("targets");
                         return _driver.Remove(targets);
                     }
                 case "ls":


### PR DESCRIPTION
This is used everywhere else in this code, but the "rm" entry is missing a return.
